### PR TITLE
fix: for sort params

### DIFF
--- a/lib/rsolr-ext/request.rb
+++ b/lib/rsolr-ext/request.rb
@@ -18,6 +18,10 @@ module RSolr::Ext::Request
         output[:start] = page * output[:rows]
       end
       
+      if sort_option = input.delete(:sort)
+        output[:sort] = sort_option
+      end
+
       # remove the input :q params
       output[:q] = input.delete :q
       output[:fq] = input.delete(:fq) if input[:fq]

--- a/lib/rsolr-ext/response.rb
+++ b/lib/rsolr-ext/response.rb
@@ -24,7 +24,7 @@ module RSolr::Ext::Response
     end
     
     def rows
-      params[:rows].try(:first).to_i
+      params[:rows]&.first&.to_i
     end
     
     def params

--- a/rsolr-ext.gemspec
+++ b/rsolr-ext.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
   s.autorequire = 'rsolr-ext'
-  s.version = "1.1.0"
+  s.version = "1.1.1"
 
   s.add_dependency 'rsolr', ">= 1.0.1"
   s.add_development_dependency 'rake', '~> 0.9.2'


### PR DESCRIPTION
変更点
- sortパラメータをそのまま入れるように変更
  - Rubyから{sort: "id desc"}を設定した際に
     sort=id%20desc
    となるはずが、
     sort=id+desc
     となっていたため
- tryメソッドがruby(2.5.0p0)でtryでエラーが出て動かなかったため、同義の新しい記述に変更